### PR TITLE
Add product catalog, cart, checkout, and admin management

### DIFF
--- a/SkuzESite/admin/orders.php
+++ b/SkuzESite/admin/orders.php
@@ -1,0 +1,30 @@
+<?php
+// Simple order listing for administrators.
+require '../includes/auth.php';
+
+$orders = $conn->query('SELECT * FROM orders ORDER BY created_at DESC');
+?>
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <title>Admin - Orders</title>
+    <link rel="stylesheet" href="../assets/style.css">
+</head>
+<body>
+<h1>Orders</h1>
+<p><a href="products.php">Manage Products</a></p>
+<table border="1" cellpadding="5">
+    <tr><th>ID</th><th>Stripe Session</th><th>Total</th><th>Created</th><th>Items</th></tr>
+    <?php while ($row = $orders->fetch_assoc()): ?>
+    <tr>
+        <td><?= $row['id'] ?></td>
+        <td><?= htmlspecialchars($row['session_id']) ?></td>
+        <td>$<?= number_format($row['total'], 2) ?></td>
+        <td><?= $row['created_at'] ?></td>
+        <td><pre><?= htmlspecialchars($row['items']) ?></pre></td>
+    </tr>
+    <?php endwhile; ?>
+</table>
+</body>
+</html>

--- a/SkuzESite/admin/products.php
+++ b/SkuzESite/admin/products.php
@@ -1,0 +1,53 @@
+<?php
+// Simple product management interface for administrators.
+require '../includes/auth.php';
+
+// Handle new product submissions
+if ($_SERVER['REQUEST_METHOD'] === 'POST') {
+    $name = trim($_POST['name']);
+    $description = trim($_POST['description']);
+    $price = (float)$_POST['price'];
+    $image = trim($_POST['image']);
+
+    if ($name && $price) {
+        $stmt = $conn->prepare('INSERT INTO products (name, description, price, image) VALUES (?, ?, ?, ?)');
+        $stmt->bind_param('ssds', $name, $description, $price, $image);
+        $stmt->execute();
+        $stmt->close();
+    }
+}
+
+$products = $conn->query('SELECT * FROM products ORDER BY id DESC');
+?>
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <title>Admin - Products</title>
+    <link rel="stylesheet" href="../assets/style.css">
+</head>
+<body>
+<h1>Products</h1>
+<p><a href="orders.php">View Orders</a></p>
+<table border="1" cellpadding="5">
+    <tr><th>ID</th><th>Name</th><th>Price</th><th>Image</th></tr>
+    <?php while ($row = $products->fetch_assoc()): ?>
+    <tr>
+        <td><?= $row['id'] ?></td>
+        <td><?= htmlspecialchars($row['name']) ?></td>
+        <td>$<?= number_format($row['price'], 2) ?></td>
+        <td><?= htmlspecialchars($row['image']) ?></td>
+    </tr>
+    <?php endwhile; ?>
+</table>
+
+<h2>Add Product</h2>
+<form method="post">
+    <label>Name <input type="text" name="name" required></label><br>
+    <label>Description <textarea name="description"></textarea></label><br>
+    <label>Price <input type="number" step="0.01" name="price" required></label><br>
+    <label>Image URL <input type="text" name="image"></label><br>
+    <button type="submit">Add</button>
+</form>
+</body>
+</html>

--- a/SkuzESite/buy.php
+++ b/SkuzESite/buy.php
@@ -1,0 +1,57 @@
+<?php
+session_start();
+require_once 'includes/db.php';
+
+// Handle add-to-cart requests. The form posts back to this page with a
+// product_id and optional quantity. Items are stored in the session under the
+// `cart` key as an associative array of product_id => qty.
+if ($_SERVER['REQUEST_METHOD'] === 'POST' && isset($_POST['product_id'])) {
+    $id = (int)$_POST['product_id'];
+    $qty = isset($_POST['qty']) ? max(1, (int)$_POST['qty']) : 1;
+
+    if (!isset($_SESSION['cart'])) {
+        $_SESSION['cart'] = [];
+    }
+    if (isset($_SESSION['cart'][$id])) {
+        $_SESSION['cart'][$id] += $qty;
+    } else {
+        $_SESSION['cart'][$id] = $qty;
+    }
+
+    // After adding to cart redirect to the cart page for feedback.
+    header('Location: cart.php');
+    exit;
+}
+
+// Fetch all products from the database to display to the user.
+$products = $conn->query('SELECT * FROM products ORDER BY name');
+?>
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <title>Products</title>
+    <link rel="stylesheet" href="assets/style.css">
+</head>
+<body>
+<h1>Products</h1>
+<p><a href="cart.php">View Cart</a></p>
+<div class="products">
+<?php while ($product = $products->fetch_assoc()): ?>
+    <div class="product">
+        <?php if (!empty($product['image'])): ?>
+            <img src="<?= htmlspecialchars($product['image']) ?>" alt="<?= htmlspecialchars($product['name']) ?>" style="max-width:150px;">
+        <?php endif; ?>
+        <h2><?= htmlspecialchars($product['name']) ?></h2>
+        <p><?= htmlspecialchars($product['description']) ?></p>
+        <p><strong>$<?= number_format($product['price'], 2) ?></strong></p>
+        <form method="post">
+            <input type="hidden" name="product_id" value="<?= $product['id'] ?>">
+            <input type="number" name="qty" value="1" min="1">
+            <button type="submit">Add to Cart</button>
+        </form>
+    </div>
+<?php endwhile; ?>
+</div>
+</body>
+</html>

--- a/SkuzESite/cancel.php
+++ b/SkuzESite/cancel.php
@@ -1,0 +1,15 @@
+<?php
+session_start();
+?>
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <title>Payment Canceled</title>
+    <link rel="stylesheet" href="assets/style.css">
+</head>
+<body>
+<h1>Payment Canceled</h1>
+<p>Your checkout was canceled. You can return to your <a href="cart.php">cart</a> to try again.</p>
+</body>
+</html>

--- a/SkuzESite/cart.php
+++ b/SkuzESite/cart.php
@@ -1,0 +1,80 @@
+<?php
+session_start();
+require_once 'includes/db.php';
+
+if (!isset($_SESSION['cart'])) {
+    $_SESSION['cart'] = [];
+}
+
+// Handle quantity updates
+if ($_SERVER['REQUEST_METHOD'] === 'POST' && isset($_POST['qty'])) {
+    foreach ($_POST['qty'] as $id => $qty) {
+        $id = (int)$id;
+        $qty = (int)$qty;
+        if ($qty <= 0) {
+            unset($_SESSION['cart'][$id]);
+        } else {
+            $_SESSION['cart'][$id] = $qty;
+        }
+    }
+    header('Location: cart.php');
+    exit;
+}
+
+$cart_items = [];
+$total = 0.0;
+
+if (!empty($_SESSION['cart'])) {
+    $ids = array_map('intval', array_keys($_SESSION['cart']));
+    $placeholders = implode(',', array_fill(0, count($ids), '?'));
+    $types = str_repeat('i', count($ids));
+    $stmt = $conn->prepare("SELECT * FROM products WHERE id IN ($placeholders)");
+    $stmt->bind_param($types, ...$ids);
+    $stmt->execute();
+    $result = $stmt->get_result();
+    while ($row = $result->fetch_assoc()) {
+        $row['quantity'] = $_SESSION['cart'][$row['id']];
+        $row['subtotal'] = $row['price'] * $row['quantity'];
+        $total += $row['subtotal'];
+        $cart_items[] = $row;
+    }
+    $stmt->close();
+}
+?>
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <title>Your Cart</title>
+    <link rel="stylesheet" href="assets/style.css">
+</head>
+<body>
+<h1>Your Cart</h1>
+<p><a href="buy.php">Continue Shopping</a></p>
+<?php if (empty($cart_items)): ?>
+    <p>Your cart is empty.</p>
+<?php else: ?>
+<form method="post">
+    <table>
+        <tr>
+            <th>Product</th>
+            <th>Price</th>
+            <th>Quantity</th>
+            <th>Subtotal</th>
+        </tr>
+        <?php foreach ($cart_items as $item): ?>
+        <tr>
+            <td><?= htmlspecialchars($item['name']) ?></td>
+            <td>$<?= number_format($item['price'], 2) ?></td>
+            <td><input type="number" name="qty[<?= $item['id'] ?>]" value="<?= $item['quantity'] ?>" min="0"></td>
+            <td>$<?= number_format($item['subtotal'], 2) ?></td>
+        </tr>
+        <?php endforeach; ?>
+    </table>
+    <p><strong>Total: $<?= number_format($total, 2) ?></strong></p>
+    <button type="submit">Update Cart</button>
+</form>
+<p><a href="checkout.php">Proceed to Checkout</a></p>
+<?php endif; ?>
+</body>
+</html>

--- a/SkuzESite/checkout.php
+++ b/SkuzESite/checkout.php
@@ -1,23 +1,60 @@
 <?php
-require 'includes/auth.php';
+// Checkout builds a Stripe session based on the contents of the user's cart
+// and stores a record of the order in the database.
+require 'includes/auth.php'; // ensures the user is logged in and provides $conn
 require_once 'vendor/autoload.php';
 
-\Stripe\Stripe::setApiKey('pk_live_51RjC8XL0dDqg6vO16qQ75R4HBfedJxO75HPP10boFERBBARlvLrMIazpcZpXEl17zIJGX81YTYoq4Al13PdsEpb1002nrKy5aQ');
+$cart = $_SESSION['cart'] ?? [];
+if (empty($cart)) {
+    header('Location: buy.php');
+    exit;
+}
+
+// Look up the product information for the items in the cart
+$ids = array_map('intval', array_keys($cart));
+$placeholders = implode(',', array_fill(0, count($ids), '?'));
+$types = str_repeat('i', count($ids));
+$stmt = $conn->prepare("SELECT * FROM products WHERE id IN ($placeholders)");
+$stmt->bind_param($types, ...$ids);
+$stmt->execute();
+$result = $stmt->get_result();
+
+$line_items = [];
+$order_items = [];
+$total = 0.0;
+while ($row = $result->fetch_assoc()) {
+    $qty = $cart[$row['id']];
+    $line_items[] = [
+        'price_data' => [
+            'currency' => 'usd',
+            'product_data' => ['name' => $row['name']],
+            'unit_amount' => (int)($row['price'] * 100),
+        ],
+        'quantity' => $qty,
+    ];
+    $order_items[] = ['id' => $row['id'], 'name' => $row['name'], 'price' => $row['price'], 'quantity' => $qty];
+    $total += $row['price'] * $qty;
+}
+$stmt->close();
+
+// Configure Stripe with a placeholder secret key. Replace with your actual key
+// in a real deployment.
+\Stripe\Stripe::setApiKey('sk_test_replace_with_real_key');
 
 $session = \Stripe\Checkout\Session::create([
-  'payment_method_types' => ['card'],
-  'line_items' => [[
-    'price_data' => [
-      'currency' => 'usd',
-      'product_data' => ['name' => 'PC Build Reservation'],
-      'unit_amount' => 5000, // $50.00
-    ],
-    'quantity' => 1,
-  ]],
-  'mode' => 'payment',
-  'success_url' => 'success.php',
-  'cancel_url' => 'cancel.php',
+    'payment_method_types' => ['card'],
+    'line_items' => $line_items,
+    'mode' => 'payment',
+    'success_url' => 'success.php',
+    'cancel_url' => 'cancel.php',
 ]);
 
-header("Location: " . $session->url);
+// Store order information tied to the Stripe session id
+$stmt = $conn->prepare('INSERT INTO orders (session_id, items, total) VALUES (?, ?, ?)');
+$json = json_encode($order_items);
+$stmt->bind_param('ssd', $session->id, $json, $total);
+$stmt->execute();
+$stmt->close();
+
+header('Location: ' . $session->url);
 exit;

--- a/SkuzESite/database.sql
+++ b/SkuzESite/database.sql
@@ -1,0 +1,17 @@
+-- SQL schema for SkuzE site
+
+CREATE TABLE IF NOT EXISTS products (
+    id INT AUTO_INCREMENT PRIMARY KEY,
+    name VARCHAR(255) NOT NULL,
+    description TEXT,
+    price DECIMAL(10,2) NOT NULL,
+    image VARCHAR(255) DEFAULT NULL
+);
+
+CREATE TABLE IF NOT EXISTS orders (
+    id INT AUTO_INCREMENT PRIMARY KEY,
+    session_id VARCHAR(255) NOT NULL,
+    items TEXT NOT NULL,
+    total DECIMAL(10,2) NOT NULL,
+    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+);

--- a/SkuzESite/includes/db.php
+++ b/SkuzESite/includes/db.php
@@ -1,14 +1,21 @@
 <?php
-$config = require __DIR__ . '/config.php';
+// Basic database connection helper. Include this file anywhere a mysqli
+// connection is needed and use the `$conn` variable.
 
+// Load configuration. The config file is located one directory above this
+// script so we traverse with `../`.
+$config = require __DIR__ . '/../config.php';
+
+// Create the connection using credentials from the config file.
 $conn = new mysqli(
-  $config['localhost:3306'],
-  $config['skuzqsas_Developer '],
-  $config['1zTh1z4n0k4yPAssw02d?!'],
-  $config['skuzqsas_MainDB']
+    $config['db_host'],
+    $config['db_user'],
+    $config['db_pass'],
+    $config['db_name']
 );
 
+// If something goes wrong stop execution so the error is visible.
 if ($conn->connect_error) {
-  die("Database connection failed: " . $conn->connect_error);
+    die('Database connection failed: ' . $conn->connect_error);
 }
 ?>

--- a/SkuzESite/success.php
+++ b/SkuzESite/success.php
@@ -1,0 +1,17 @@
+<?php
+session_start();
+unset($_SESSION['cart']);
+?>
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <title>Payment Successful</title>
+    <link rel="stylesheet" href="assets/style.css">
+</head>
+<body>
+<h1>Thank you for your purchase!</h1>
+<p>Your order was completed successfully.</p>
+<p><a href="buy.php">Return to products</a></p>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- Add SQL schema for `products` and `orders` tables.
- Implement database helper and dynamic product listing with session-based cart.
- Build Stripe checkout from cart, store orders, and add admin pages for managing products and orders.
- Use prepared statements for cart and checkout product lookups and add success/cancel endpoints.

## Testing
- `php -l SkuzESite/buy.php`
- `php -l SkuzESite/cart.php`
- `php -l SkuzESite/checkout.php`
- `php -l SkuzESite/cancel.php`
- `php -l SkuzESite/success.php`
- `php -l SkuzESite/admin/products.php`
- `php -l SkuzESite/admin/orders.php`


------
https://chatgpt.com/codex/tasks/task_e_689b06bd2230832bb7d50cc91393f22d