### PR TITLE
Add mobile-first layout and touch-friendly upload

### DIFF
--- a/SkuzESite/assets/style.css
+++ b/SkuzESite/assets/style.css
@@ -1,39 +1,113 @@
-<style>
-  body {
-    background: var(--bg, #fff);
-    color: var(--fg, #000);
-    font-family: Georgia, serif;
-    margin: 0;
-    padding: 1rem;
-  }
+body {
+  background: var(--bg, #fff);
+  color: var(--fg, #000);
+  font-family: Georgia, serif;
+  margin: 0;
+  padding: 1rem;
+}
 
-  .hero {
-    text-align: center;
-    padding: 2rem 1rem;
-  }
-  .hero pre {
-    font-family: monospace;
-    font-size: 0.9rem;
-    margin-bottom: 1rem;
-    color: var(--fg, #000);
-  }
+.hero {
+  text-align: center;
+  padding: 2rem 1rem;
+}
+.hero pre {
+  font-family: monospace;
+  font-size: 0.9rem;
+  margin-bottom: 1rem;
+  color: var(--fg, #000);
+}
+
+.cta-buttons {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+  max-width: 300px;
+  margin: 1rem auto;
+}
+.cta-buttons a {
+  text-decoration: none;
+  text-align: center;
+  padding: 0.75rem;
+  background: var(--accent, #0055cc);
+  color: white;
+  border-radius: 5px;
+  transition: 0.2s;
+}
+.cta-buttons a:hover {
+  opacity: 0.9;
+}
+
+/* Mobile-first form and button styles */
+form {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+input,
+select,
+textarea,
+button {
+  font: inherit;
+  padding: 0.75rem;
+  border: 1px solid #ccc;
+  border-radius: 4px;
+  box-sizing: border-box;
+  width: 100%;
+}
+button {
+  background: var(--accent, #0055cc);
+  color: #fff;
+  cursor: pointer;
+}
+button:hover {
+  opacity: 0.9;
+}
+
+/* Navigation */
+nav {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+nav a {
+  text-decoration: none;
+  color: var(--fg, #000);
+  padding: 0.5rem;
+}
+
+/* Drag-and-drop upload */
+.drop-area {
+  border: 2px dashed var(--accent, #0055cc);
+  border-radius: 5px;
+  padding: 1rem;
+  text-align: center;
+  margin-bottom: 1rem;
+}
+.drop-area.dragover {
+  background: #f0f8ff;
+}
+#fileElem {
+  display: none;
+}
+#fileSelect {
+  margin-top: 0.5rem;
+}
+
+/* Larger screens */
+@media (min-width: 600px) {
   .cta-buttons {
-    display: flex;
-    flex-direction: column;
-    gap: 1rem;
-    max-width: 300px;
-    margin: 1rem auto;
+    flex-direction: row;
   }
-  .cta-buttons a {
-    text-decoration: none;
-    text-align: center;
-    padding: 0.75rem;
-    background: var(--accent, #0055cc);
-    color: white;
-    border-radius: 5px;
-    transition: 0.2s;
+  nav {
+    flex-direction: row;
+    justify-content: center;
   }
-  .cta-buttons a:hover {
-    opacity: 0.9;
+  form {
+    max-width: 500px;
+    margin: 0 auto;
   }
-</style>
+  button {
+    width: auto;
+    align-self: flex-start;
+  }
+}

--- a/SkuzESite/service-step.php
+++ b/SkuzESite/service-step.php
@@ -22,7 +22,7 @@ function label($text, $name, $type = 'text', $required = true) {
   <a class="logo-link" href="index.php"><img src="assets/logo.png" alt="SkuzE Logo"></a>
   <h2>Describe Your <?= htmlspecialchars(ucfirst($category)) ?> Issue</h2>
 
-  <form method="post" action="submit-request.php">
+  <form method="post" action="submit-request.php" enctype="multipart/form-data">
     <input type="hidden" name="category" value="<?= htmlspecialchars($category) ?>">
 
     <?php if ($category === 'phone' || $category === 'console' || $category === 'pc'): ?>
@@ -45,7 +45,40 @@ function label($text, $name, $type = 'text', $required = true) {
       <?php label("Problem Description", "issue"); ?>
     <?php endif; ?>
 
+    <div id="drop-area" class="drop-area">
+      <p>Drag & drop a photo here or</p>
+      <button id="fileSelect" type="button">Choose a file</button>
+      <input type="file" id="fileElem" name="photo" accept="image/*">
+    </div>
+
     <button type="submit">Review and Submit</button>
   </form>
+
+  <script>
+    const dropArea = document.getElementById('drop-area');
+    const fileInput = document.getElementById('fileElem');
+    const fileSelect = document.getElementById('fileSelect');
+
+    fileSelect.addEventListener('click', () => fileInput.click());
+
+    ['dragenter', 'dragover'].forEach(evt => {
+      dropArea.addEventListener(evt, e => {
+        e.preventDefault();
+        dropArea.classList.add('dragover');
+      });
+    });
+
+    ['dragleave', 'drop'].forEach(evt => {
+      dropArea.addEventListener(evt, e => {
+        e.preventDefault();
+        dropArea.classList.remove('dragover');
+      });
+    });
+
+    dropArea.addEventListener('drop', e => {
+      e.preventDefault();
+      fileInput.files = e.dataTransfer.files;
+    });
+  </script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- refactor global stylesheet with mobile-first form, button, navigation and drag‑and‑drop upload styles
- support drag-and-drop photo uploads with a fallback button for touch devices

## Testing
- `php -l SkuzESite/service-step.php`


------
https://chatgpt.com/codex/tasks/task_e_689bb8d22eb8832bb4657f9d085df50b